### PR TITLE
add test to makefile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,10 @@
 		  "python.defaultInterpreterPath": "/home/vscode/venv/bin/python"
 		},
 		"extensions": [
-		  "ms-python.python",
-		  "ms-python.vscode-pylance",
-		  "GitHub.copilot-chat"
+			"ms-python.python",
+			"ms-python.vscode-pylance",
+			"GitHub.copilot-chat",
+			"ms-vscode.makefile-tools"
 		]
 	  }
 	},

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ HOST := 0.0.0.0
 run:
 	/home/vscode/venv/bin/uvicorn --host $(HOST) $(APP_MODULE) --reload
 
+test:
+	/home/vscode/venv/bin/pytest
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""


### PR DESCRIPTION
This pull request mainly focuses on enhancing the development environment and introducing a new test command in the `Makefile`. The key changes include the addition of the `ms-vscode.makefile-tools` extension in the `.devcontainer/devcontainer.json` file and the introduction of a `test` command in the `Makefile`.

* **Development Environment Enhancement:**
  * [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L26-R27): Added the `ms-vscode.makefile-tools` extension to the list of extensions. This extension aids in working with Makefiles in VS Code, thus improving the development environment.

* **Makefile Updates:**
  * [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12-R14): Introduced a new `test` command that runs tests using `pytest`. This addition simplifies the process of running tests in the development environment.